### PR TITLE
Fix ComponentizedBuilderTests and MultiStageComponentizedBuilderTests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+          "version": "2.2.2"
+        }
+      },
+      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveX/RxSwift", from: "6.5.0"),
+        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.2.2"), // for testTarget only
     ],
     targets: [
         .target(
@@ -20,7 +21,7 @@ let package = Package(
         ),
         .testTarget(
             name: "RIBsTests",
-            dependencies: ["RIBs"],
+            dependencies: ["RIBs", "CwlPreconditionTesting"],
             path: "RIBsTests"
         ),
     ]

--- a/RIBsTests/ComponentizedBuilderTests.swift
+++ b/RIBsTests/ComponentizedBuilderTests.swift
@@ -16,6 +16,7 @@
 
 @testable import RIBs
 import XCTest
+import CwlPreconditionTesting
 
 class ComponentizedBuilderTests: XCTestCase {
 
@@ -29,10 +30,16 @@ class ComponentizedBuilderTests: XCTestCase {
         }
 
         let _: MockSimpleRouter = sameInstanceBuilder.build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
-
-        expectAssertionFailure {
+        
+        let options = XCTExpectedFailure.Options()
+        options.issueMatcher = { issue in
+            issue.type == .assertionFailure
+        }
+        
+        let assertionFailureException = catchBadInstruction {
             let _: MockSimpleRouter = sameInstanceBuilder.build(withDynamicBuildDependency: (), dynamicComponentDependency: ())
         }
+        XCTAssertNotNil(assertionFailureException, "Builder should not return the same instance for the same component. Assertion failure is triggered.")
     }
 
     func test_componentForCurrentPass_builderReturnsNewInstance_verifyNoAssertion() {

--- a/RIBsTests/MultiStageComponentizedBuilderTests.swift
+++ b/RIBsTests/MultiStageComponentizedBuilderTests.swift
@@ -16,6 +16,7 @@
 
 @testable import RIBs
 import XCTest
+import CwlPreconditionTesting
 
 class MultiStageComponentizedBuilderTests: XCTestCase {
 
@@ -64,13 +65,15 @@ class MultiStageComponentizedBuilderTests: XCTestCase {
 
         _ = sameInstanceBuilder.finalStageBuild(withDynamicDependency: 92393)
 
-        expectAssertionFailure {
+        let finalStageBuildFatalErrorException = catchBadInstruction {
             _ = sameInstanceBuilder.finalStageBuild(withDynamicDependency: 92393)
         }
+        XCTAssertNotNil(finalStageBuildFatalErrorException, "fatalError expected")
 
-        expectAssertionFailure {
+        let componentForCurrentBuildPassAssertionFailureException = catchBadInstruction {
             _ = sameInstanceBuilder.componentForCurrentBuildPass
         }
+        XCTAssertNotNil(componentForCurrentBuildPassAssertionFailureException, "Assertion failure expected")
     }
 }
 


### PR DESCRIPTION
This PR fixes unit-testing compilation issue described in https://github.com/uber/RIBs-iOS/issues/10

It adds https://github.com/mattgallagher/CwlPreconditionTesting as a test target dependency to catch `assertionFailure` and `fatalError` calls thrown in `ComponentizedBuilder` and in `MultiStageComponentizedBuilder`.

This opens up ability to add more unit-tests https://github.com/uber/RIBs-iOS/issues/5 and paves the way for CI/CD setup https://github.com/uber/RIBs-iOS/issues/9