### PR TITLE
ci: restrict workflow token to read-only

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -2,6 +2,9 @@ name: CI iOS
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: macos-latest


### PR DESCRIPTION
Adds explicit `permissions: contents: read` to the iOS CI workflow.

The workflow checks out source, installs CocoaPods dependencies, runs tests via xcodebuild, and lints the podspec. None of these operations need write access to the repository or GitHub API. Restricting the token scope follows least-privilege guidance for Actions workflows.